### PR TITLE
Xcode 16対応

### DIFF
--- a/SwiftTask/_RecursiveLock.swift
+++ b/SwiftTask/_RecursiveLock.swift
@@ -28,8 +28,8 @@ internal final class _RecursiveLock
         pthread_mutexattr_destroy(self.attribute)
         pthread_mutex_destroy(self.mutex)
         
-        self.attribute.deallocate(capacity: 1)
-        self.mutex.deallocate(capacity: 1)
+        self.attribute.deallocate()
+        self.mutex.deallocate()
     }
     
     internal func lock()


### PR DESCRIPTION
deallocate(capacity:) が廃止されたので、警告通りに deallocate() を使う
（以前から警告は出ていたが放置されていた）

<img width="855" alt="image" src="https://github.com/user-attachments/assets/3bf5b2b7-8d68-47a1-92a4-c7984c295266">
